### PR TITLE
Force restart the service

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Run the container
 
 ```
-docker run --net=host -p 8080:8080 -t kudoz/npm-proxy-cache
+docker run --restart=always --net=host -p 8080:8080 -t kudoz/npm-proxy-cache
 ```
 
 Use it with `npm`, replacing the npm-proxy-cache hostname below with the ip or hostname you have the container above running at.


### PR DESCRIPTION
Any simple ```curl -I http://uva.srv.corp.folha.com.br:8080``` kill the server with error.

![uva-proxy](https://cloud.githubusercontent.com/assets/750007/17637247/a4a5eaf6-60b8-11e6-9f83-8ba987572574.png)
